### PR TITLE
Use dynamic URL for tdb if no tdb server provided

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -84,7 +84,6 @@ jobs:
         cd packages/tdb-dashboard
         echo '
             CONNECTION_TYPE="LOCAL"
-            TERMINUSDB_SERVER=http://127.0.0.1:6363/
             TERMINUSDB_KEY=root
             FEEDBACK_URL="https://cloud.terminusdb.com/"
             BASE_URL="dashboard"

--- a/packages/tdb-dashboard/localSettings.js
+++ b/packages/tdb-dashboard/localSettings.js
@@ -1,4 +1,4 @@
-const server = localStorage.getItem("terminusdb-server-override") || process.env.TERMINUSDB_SERVER 
+const server = localStorage.getItem("terminusdb-server-override") || process.env.TERMINUSDB_SERVER || window.location.origin
 
 //there is no default key
 //let key=  localStorage.getItem("terminusdb-key-override") || process.env.TERMINUSDB_KEY 


### PR DESCRIPTION
Previously the local dashboard builds were hard-compiled to use localhost:6363. This creates the problem that if the user chooses a different port, the dashboard will stop working as it still tries to connect to localhost:6363 instead. Therefore I use the window.url.origin to determine where the dashboard is served if the ENV variable is not provided.