### PR TITLE
Bug 312 alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,22 @@ cp ENV.local .env
 
 npm run build
 ```
-You can find the builded version into terminusdb-dashboard/packages/tdb-dashboard/dist
+You can find the built version into terminusdb-dashboard/packages/tdb-dashboard/dist
+
+**Locally Developing the dashboard**
+
+Running `npm run start` instead of `build` starts a server and watches for changes. Because of the way this is configured, you will need to go to `/dashboard` after connecting in browser
+
+```sh
+npm run start
+```
+
+There are some differences depending on how you are developing it, if you are just running the dashboard repo locally:
+
+- Comment out the `@terminusdb/terminusdb-client` alias in the webpack config
+- Update the env file to have the `BASE_URL` be empty (also generally useful since this is where the webpack server opens the new browser window), this will mean you don't have to go to `/dashboard` as above
+
+There is some additional configuration needed if you are wanting to run with Auth0 Login, essentially you just need a proxy and to setup the right auth0 config. This will allow you to login but the token generated will not be valid so you will need to replace it manually with a valid one.
 
 ## Publishing
 

--- a/packages/tdb-access-control-component/package.json
+++ b/packages/tdb-access-control-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terminusdb/terminusdb-access-control-component",
-  "version": "6.0.10",
+  "version": "6.2.5",
   "description": "Table for terminusdb",
   "main": "src/index",
   "module": "es6/index",

--- a/packages/tdb-dashboard/package.json
+++ b/packages/tdb-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terminusdb-live/tdb-dashboard",
-  "version": "6.0.10",
+  "version": "6.2.5",
   "description": "react",
   "homepage": "./",
   "main": "src/index",

--- a/packages/tdb-dashboard/src/components/SubmitChangeRequestModal.js
+++ b/packages/tdb-dashboard/src/components/SubmitChangeRequestModal.js
@@ -2,6 +2,7 @@ import React, {useRef, useState} from "react"
 import {Modal, Button, Form} from "react-bootstrap" 
 import { Alerts } from "./Alerts"
 import {ChangeRequest} from "../hooks/ChangeRequest"
+import { TERMINUS_DANGER } from "./constants"
 import { CHANGE_REQUEST_SUBMIT_REVIEW, CHANGE_REQUEST_MESSAGE_FOR_REVIEW } from "../cypress.constants"
 
 export const SubmitChangeRequestModal = ({showModal, setShowModal , updateParent, updateChangeRequestID, operation}) => { 
@@ -41,8 +42,7 @@ export const SubmitChangeRequestModal = ({showModal, setShowModal , updateParent
             <Button variant="close" aria-label="Close" onClick={closeModal} />
         </Modal.Header>
         <Modal.Body className="p-3">
-            {errorMessage && 
-             <Alert variant="danger"  onClose={() => setError(false)} dismissible>{errorMessage}</Alert>}
+            {errorMessage && <Alerts type={TERMINUS_DANGER} onCancel={() => setError(false)} message={errorMessage}/>}
             <Form>
                 <Form.Group className="mb-3 tdb__input">
                     <Form.Control required 

--- a/packages/tdb-dashboard/webpack_dev.config.js
+++ b/packages/tdb-dashboard/webpack_dev.config.js
@@ -65,7 +65,9 @@ module.exports = (env, argv) => ({
               }
             ],"@babel/plugin-transform-react-jsx",
               "@babel/plugin-proposal-export-default-from","@babel/plugin-transform-regenerator",
-            ["@babel/plugin-transform-runtime"]
+            ["@babel/plugin-transform-runtime"],
+            ["@babel/plugin-proposal-private-property-in-object", { "loose": true }],
+            ["@babel/plugin-proposal-private-methods", { "loose": true }],
             ]
           }
         },

--- a/packages/tdb-documents-ui-template/package.json
+++ b/packages/tdb-documents-ui-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terminusdb/terminusdb-documents-ui-template",
-  "version": "6.0.10",
+  "version": "6.2.5",
   "description": "SDK to build Application from terminusdb documents",
   "main": "src/index.js",
   "module": "es6/index.js",

--- a/packages/tdb-documents-ui/package.json
+++ b/packages/tdb-documents-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terminusdb/terminusdb-documents-ui",
-  "version": "6.0.10",
+  "version": "6.2.5",
   "description": "SDK to build UI from terminusdb documents",
   "main": "src/index.js",
   "module": "es6/index",

--- a/packages/tdb-react-components/package.json
+++ b/packages/tdb-react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terminusdb-live/tdb-react-components",
-  "version": "6.0.10",
+  "version": "6.2.5",
   "description": "components tools for terminusdb",
   "main": "src/index",
   "module": "es6/index",

--- a/packages/tdb-react-table/package.json
+++ b/packages/tdb-react-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terminusdb/terminusdb-react-table",
-  "version": "6.0.10",
+  "version": "6.2.5",
   "description": "Table for terminusdb",
   "main": "src/index",
   "module": "es6/index",


### PR DESCRIPTION
Closes https://github.com/terminusdb/terminusdb-dashboard/issues/312

This fixes the way the alert component is handled in the `SubmitChangeRequestModal` file. Since this was previously changed to use `Alerts` instead of just `Alert` this file was not updated.

This also adds a section to the readme to help with local development, and some fixes to the webpack config to hide warnings